### PR TITLE
Example: Custom headers

### DIFF
--- a/platform/core/src/classes/metadata/StudyMetadata.js
+++ b/platform/core/src/classes/metadata/StudyMetadata.js
@@ -7,6 +7,7 @@ import OHIFError from '../OHIFError';
 import { SeriesMetadata } from './SeriesMetadata';
 // - createStacks
 import { api } from 'dicomweb-client';
+import OHIF from '@ohif/core';
 // - createStacks
 import { isImage } from '../../utils/isImage';
 import {
@@ -979,7 +980,10 @@ function _getDisplaySetFromSopClassModule(
   }
 
   const plugin = handlersForSopClassUID[0];
-  const headers = DICOMWeb.getAuthorizationHeader();
+  const headers = {
+    ...DICOMWeb.getAuthorizationHeader(),
+    ...OHIF.user.getHeaders()
+  };
   const errorInterceptor = errorHandler.getHTTPErrorHandler();
   const dicomWebClient = new dwc({
     url: study.getData().wadoRoot,

--- a/platform/core/src/studies/services/qido/studies.js
+++ b/platform/core/src/studies/services/qido/studies.js
@@ -1,4 +1,5 @@
 import { api } from 'dicomweb-client';
+import OHIF from '@ohif/core';
 import StaticWadoClient from './StaticWadoClient';
 import DICOMWeb from '../../../DICOMWeb/';
 
@@ -120,7 +121,10 @@ export default function Studies(server, filter) {
   const config = {
     ...server,
     url: server.qidoRoot,
-    headers: DICOMWeb.getAuthorizationHeader(server),
+    headers: {
+      ...DICOMWeb.getAuthorizationHeader(server),
+      ...OHIF.user.getHeaders(),
+    },
     errorInterceptor: errorHandler.getHTTPErrorHandler(),
     requestHooks: [getXHRRetryRequestHook()],
   };

--- a/platform/core/src/studies/services/wado/retrieveMetadataLoaderAsync.js
+++ b/platform/core/src/studies/services/wado/retrieveMetadataLoaderAsync.js
@@ -1,5 +1,6 @@
 import StaticWadoClient from '../qido/StaticWadoClient';
 import dcmjs from 'dcmjs';
+import OHIF from '@ohif/core';
 import DICOMWeb from '../../../DICOMWeb/';
 import RetrieveMetadataLoader from './retrieveMetadataLoader';
 import { sortStudySeries, sortingCriteria } from '../../sortStudy';
@@ -76,7 +77,10 @@ export default class RetrieveMetadataLoaderAsync extends RetrieveMetadataLoader 
     const client = new StaticWadoClient({
       ...server,
       url: server.qidoRoot,
-      headers: DICOMWeb.getAuthorizationHeader(server),
+      headers: {
+        ...DICOMWeb.getAuthorizationHeader(server),
+        ...OHIF.user.getHeaders(),
+      },
       errorInterceptor: errorHandler.getHTTPErrorHandler(),
       requestHooks: [getXHRRetryRequestHook()],
     });

--- a/platform/core/src/studies/services/wado/retrieveMetadataLoaderSync.js
+++ b/platform/core/src/studies/services/wado/retrieveMetadataLoaderSync.js
@@ -1,4 +1,5 @@
 import { api } from 'dicomweb-client';
+import OHIF from '@ohif/core';
 import DICOMWeb from '../../../DICOMWeb/';
 import { createStudyFromSOPInstanceList } from './studyInstanceHelpers';
 import RetrieveMetadataLoader from './retrieveMetadataLoader';
@@ -60,7 +61,10 @@ export default class RetrieveMetadataLoaderSync extends RetrieveMetadataLoader {
     const { server } = this;
     const client = new api.DICOMwebClient({
       url: server.wadoRoot,
-      headers: DICOMWeb.getAuthorizationHeader(server),
+      headers: {
+        ...DICOMWeb.getAuthorizationHeader(server),
+        ...OHIF.user.getHeaders(),
+      },
       errorInterceptor: errorHandler.getHTTPErrorHandler(),
       requestHooks: [getXHRRetryRequestHook()],
     });

--- a/platform/core/src/user.js
+++ b/platform/core/src/user.js
@@ -1,3 +1,5 @@
+let _headers = {};
+
 // These should be overridden by the implementation
 let user = {
   userLoggedIn: () => false,
@@ -8,6 +10,10 @@ let user = {
   logout: () => new Promise((resolve, reject) => reject()),
   getData: key => null,
   setData: (key, value) => null,
+  setHeaders: headers => {
+    _headers = { ..._headers, ...headers };
+  },
+  getHeaders: () => _headers,
 };
 
 export default user;

--- a/platform/core/src/utils/dicomLoaderService.js
+++ b/platform/core/src/utils/dicomLoaderService.js
@@ -1,6 +1,7 @@
 import cornerstone from 'cornerstone-core';
 import cornerstoneWADOImageLoader from 'cornerstone-wado-image-loader';
 import { api } from 'dicomweb-client';
+import OHIF from '@ohif/core';
 import DICOMWeb from '../DICOMWeb';
 
 import errorHandler from '../errorHandler';
@@ -60,7 +61,10 @@ const wadorsRetriever = (
   studyInstanceUID,
   seriesInstanceUID,
   sopInstanceUID,
-  headers = DICOMWeb.getAuthorizationHeader(),
+  headers = {
+    ...DICOMWeb.getAuthorizationHeader(),
+    ...OHIF.user.getHeaders(),
+  },
   errorInterceptor = errorHandler.getHTTPErrorHandler()
 ) => {
   const config = {

--- a/platform/core/src/utils/metadataProvider/fetchOverlayData.js
+++ b/platform/core/src/utils/metadataProvider/fetchOverlayData.js
@@ -1,4 +1,5 @@
 import { api } from 'dicomweb-client';
+import OHIF from '@ohif/core';
 import DICOMWeb from '../../DICOMWeb';
 import str2ab from '../str2ab';
 import unpackOverlay from './unpackOverlay';
@@ -68,7 +69,10 @@ async function _getOverlayData(tag, server) {
 
   const config = {
     url: server.wadoRoot, //BulkDataURI is absolute, so this isn't used
-    headers: DICOMWeb.getAuthorizationHeader(server),
+    headers: {
+      ...DICOMWeb.getAuthorizationHeader(server),
+      ...OHIF.user.getHeaders(),
+    },
     errorInterceptor: errorHandler.getHTTPErrorHandler(),
     requestHooks: [getXHRRetryRequestHook()],
   };

--- a/platform/core/src/utils/metadataProvider/fetchPaletteColorLookupTableData.js
+++ b/platform/core/src/utils/metadataProvider/fetchPaletteColorLookupTableData.js
@@ -1,4 +1,5 @@
 import { api } from 'dicomweb-client';
+import OHIF from '@ohif/core';
 import DICOMWeb from '../../DICOMWeb';
 import str2ab from '../str2ab';
 
@@ -140,7 +141,10 @@ function _getPaletteColor(server, paletteColorLookupTableData, lutDescriptor) {
 
     const config = {
       url: server.wadoRoot, //BulkDataURI is absolute, so this isn't used
-      headers: DICOMWeb.getAuthorizationHeader(server),
+      headers: {
+        ...DICOMWeb.getAuthorizationHeader(server),
+        ...OHIF.user.getHeaders(),
+      },
       errorInterceptor: errorHandler.getHTTPErrorHandler(),
       requestHooks: [getXHRRetryRequestHook()],
     };

--- a/platform/viewer/public/config/default.js
+++ b/platform/viewer/public/config/default.js
@@ -18,9 +18,9 @@ window.config = {
     dicomWeb: [
       {
         name: 'DCM4CHEE',
-        wadoUriRoot: 'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/wado',
-        qidoRoot: 'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs',
-        wadoRoot: 'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs',
+        wadoUriRoot: 'http://localhost:8001/dcm4chee-arc/aets/DCM4CHEE/wado',
+        qidoRoot: 'http://localhost:8001/dcm4chee-arc/aets/DCM4CHEE/rs',
+        wadoRoot: 'http://localhost:8001/dcm4chee-arc/aets/DCM4CHEE/rs',
         qidoSupportsIncludeField: true,
         imageRendering: 'wadors',
         thumbnailRendering: 'wadors',

--- a/platform/viewer/src/routes/ViewerRouting.js
+++ b/platform/viewer/src/routes/ViewerRouting.js
@@ -37,6 +37,19 @@ function ViewerRouting({ match: routeMatch, location: routeLocation }) {
   let query = useQuery();
   const authToken = query.get('token');
 
+  /**
+   * Gets context via query strings and set custom headers
+   * to be sent on every dicomweb-client request.
+   *
+   * In order for this to work, cors needs to be enabled in the server.
+   */
+  const studyPoolUID = query.get('studyPoolUID');
+  const userUID = query.get('userUID');
+  user.setHeaders({
+    'study-pool-uid': studyPoolUID,
+    'user-uid': userUID,
+  });
+
   if (authToken) {
     user.getAccessToken = () => authToken;
   }

--- a/platform/viewer/src/studylist/StudyListRoute.js
+++ b/platform/viewer/src/studylist/StudyListRoute.js
@@ -21,11 +21,27 @@ import filesToStudies from '../lib/filesToStudies.js';
 import UserManagerContext from '../context/UserManagerContext';
 import WhiteLabelingContext from '../context/WhiteLabelingContext';
 import AppContext from '../context/AppContext';
+import useQuery from '../customHooks/useQuery.js';
 
 const { urlUtil: UrlUtil } = OHIF.utils;
 
 function StudyListRoute(props) {
   const { history, server, user, studyListFunctionsEnabled } = props;
+
+  /**
+   * Gets context via query strings and set custom headers
+   * to be sent on every dicomweb-client request.
+   *
+   * In order for this to work, cors needs to be enabled in the server.
+   */
+  let query = useQuery();
+  const studyPoolUID = query.get('studyPoolUID');
+  const userUID = query.get('userUID');
+  OHIF.user.setHeaders({
+    'study-pool-uid': studyPoolUID,
+    'user-uid': userUID,
+  });
+
   const [t] = useTranslation('Common');
   // ~~ STATE
   const [sort, setSort] = useState({


### PR DESCRIPTION
- Usage: http://localhost:3000/viewer/1.3.6.1.4.1.14519.5.2.1.6655.2359.247426265538388028079845922798?userUID=123&studyPoolUID=321